### PR TITLE
Install dependencies not automatically present in Docker

### DIFF
--- a/tools/make_deps.sh
+++ b/tools/make_deps.sh
@@ -4,7 +4,12 @@ echo "ubuntu deps..."
 echo ""
 sudo apt-get install \
   build-essential \
-  autotools-dev
+  autotools-dev \
+  autoconf \
+  bc \
+  unzip \
+  python \
+  clang
 echo "ubuntu deps... done"
 
 echo "gyp... "


### PR DESCRIPTION
Add autoconf, bc, unzip, python, and clang packages, all of which are missing by default in Docker's primary Debian image.